### PR TITLE
Plugin config, enable/disable, customization

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -20,6 +20,14 @@
                                 "args": {"file": "${packages}/sublimetext_python_checker/sublimetext_python_checker.sublime-settings"},
                                 "caption": "Settings – Default"
                             },
+                            {
+                                "command": "toggle_setting",
+                                "args": {
+                                    "setting": "python_checking"
+                                },
+                                "checkbox": true,
+                                "caption": "Enabled (current buffer)"
+                            },
                             { "caption": "-" }
                         ]
                     }

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,30 @@
+[
+    {
+        "caption": "Preferences",
+        "mnemonic": "n",
+        "id": "preferences",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption": "sublimetext_python_checker",
+                        "children":
+                        [
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/sublimetext_python_checker/sublimetext_python_checker.sublime-settings"},
+                                "caption": "Settings – Default"
+                            },
+                            { "caption": "-" }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/README.markdown
+++ b/README.markdown
@@ -10,14 +10,20 @@ Go to your Packages dir (Sublime Text 2 -> Preferences -> Browse Packages). Clon
 
     git clone git://github.com/vorushin/sublimetext_python_checker.git
 
-Go to sublimetext_python_checker/ and create file local_settings.py with list of your preferred checkers:
+From SublimeText 2 -> Preferences -> Package Settings, select `sublime_python_checker`. Add something like this:
 
-<pre>
-    CHECKERS = [('/Users/vorushin/.virtualenvs/checkers/bin/pep8', []),
-                ('/Users/vorushin/.virtualenvs/checkers/bin/pyflakes', [])]
-</pre>
+```
+{
+    "highlight_color": "keyword",
+    "python_syntax_checkers": [
+            ["/usr/bin/pep8", []],
+            ["/usr/bin/pyflakes", []]
+    ]
+}
+```
+You should replace `keyword` with a theme style of your preference.
 
-First parameter is path to command, second - optional list of arguments. If you want to disable line length checking in pep8, set second parameter to ['--ignore=E501'].
+The first parameter in a `python_syntax_checkers` entry is the path to command, the second one an optional list of arguments. E.g. if you want to disable line length checking in pep8, you should set the second parameter to ['--ignore=E501'].
 
 You can also set syntax checkers using sublimetext settings (per file, global,
 per project, ...):
@@ -30,8 +36,8 @@ per project, ...):
         ]
     }
 </pre>
-Both "CHECKERS local_settings" and sublime text settings will be used,
-but sublime text settings are prefered. (using syntax checker binary name)
+
+These will have precedence over plugin-level settings.
 
 Restart SublimeText 2 and open some *.py file to see check results. You can see additional information in python console of your editor (go View -> Show Console).
 

--- a/README.markdown
+++ b/README.markdown
@@ -39,7 +39,22 @@ per project, ...):
 
 These will have precedence over plugin-level settings.
 
+You can enable/disable checking for a particular view by going to Preferences -> Package Settings -> sublime_python_checker and checking the `Enabled` option. If you want, you can bind a key to this action: Preferences -> "Key Bindings (User)". E.g.:
+
+```
+[
+ { "keys": ["ctrl+shift+l"], "command": "toggle_setting",
+   "args": {"setting": "python_checking"}}
+]
+```
+
 Restart SublimeText 2 and open some *.py file to see check results. You can see additional information in python console of your editor (go View -> Show Console).
+
+## Configuration Options
+
+  * `python_syntax_checkers` - list of lists - each sub-list is a `[path, [options]]` list pair
+  * `highlight_color` - string - theme style that should be used to highlight problems
+  * `enabled_by_default` - boolean - whether or not checking should be active by default when a file is opened
 
 ## Why not sublimelint
 

--- a/local_settings.py.example
+++ b/local_settings.py.example
@@ -1,9 +1,0 @@
-'''
-First parameter is path to command, second - optional list of arguments.
-If you want to disable line length checking in pep8, set second parameter
-to ['--ignore=E501']. Look at output of pep8 --help for more options.
-'''
-CHECKERS = [('/Users/vorushin/.virtualenvs/checkers/bin/pep8', []),
-            ('/Users/vorushin/.virtualenvs/checkers/bin/pyflakes', [])]
-
-

--- a/python_checker.py
+++ b/python_checker.py
@@ -6,51 +6,19 @@ from subprocess import Popen, PIPE
 import sublime
 import sublime_plugin
 
-try:
-    from local_settings import CHECKERS
-except ImportError as e:
-    print '''
-Please create file local_settings.py in the same directory with
-python_checker.py. Add to local_settings.py list of your checkers.
-
-Example:
-
-CHECKERS = [('/Users/vorushin/.virtualenvs/checkers/bin/pep8', []),
-            ('/Users/vorushin/.virtualenvs/checkers/bin/pyflakes', [])]
-
-First parameter is path to command, second - optional list of arguments.
-If you want to disable line length checking in pep8, set second parameter
-to ['--ignore=E501'].
-
-You can also insert checkers using sublime settings.
-
-For example in your project settings, add:
-    "settings":
-    {
-        "python_syntax_checkers":
-        [
-            ["/usr/bin/pep8", ["--ignore=E501,E128,E221"] ],
-            ["/usr/bin/pyflakes", [] ]
-        ]
-    }
-'''
-
-
-global view_messages
-view_messages = {}
-
-settings = sublime.load_settings("sublimetext_python_checker.sublime-settings")
-
-global check_enabled
-check_enabled = settings.get('check_enabled', True)
-
 global buffer_state
+global view_messages
+global check_enabled
+
+view_messages = {}
+settings = sublime.load_settings("sublimetext_python_checker.sublime-settings")
+check_enabled = settings.get('check_enabled', True)
 buffer_state = {}
 
 
 def set_status(view, state):
     buffer_state[view.id()] = state
-    view.set_status('python_checker_status',
+    view.set_status('pthon_checker_status',
                     "pylint/pyflakes {0}".format('on' if state else 'off'))
 
 
@@ -120,14 +88,8 @@ def check_and_mark(view):
     if not view.file_name():  # we check files (not buffers)
         return
 
-    checkers = view_settings.get('python_syntax_checkers', [])
-
-    # Append "local_settings.CHECKERS" to checkers from settings
-    if 'CHECKERS' in globals():
-        checkers_basenames = [
-            os.path.basename(checker[0]) for checker in checkers]
-        checkers.extend([checker for checker in CHECKERS
-                         if os.path.basename(checker[0]) not in checkers_basenames])
+    checkers = view_settings.get('python_syntax_checkers',
+        settings.get('python_syntax_checkers', {}))
 
     messages = []
     for checker, args in checkers:

--- a/python_checker.py
+++ b/python_checker.py
@@ -15,7 +15,7 @@ enabled_by_default = settings.get('enabled_by_default', True)
 
 def set_status(view, state):
     view.set_status('pthon_checker_status',
-                    "pylint/pyflakes {0}".format('on' if state else 'off'))
+                    "pep8/pyflakes {0}".format('on' if state else 'off'))
 
 
 class PythonCheckerListener(sublime_plugin.EventListener):


### PR DESCRIPTION
Hi!
I've added some functionality to your plugin and thought that maybe you'd like to merge it. I think these are all useful simple features that people expect from a plugin.

So, this patch includes three main features:
- A plugin-level "standard" *.sublime-settings config file instead of `local_settings.py`
- A menu option that enables/disables checking for a specific view, and that can be bound to a key combination
- Status bar display of plugin state (enable/disabled)
- Two new configuration options:
  - `enabled_by_default`, that allows people working on heavy projects to leave the plugin off by default
  - `highlight_color`, which allows the user to set the theme style that will be used for highlighting

I think that's it. I hope it's not too many changes for a single pull request.

Thanks for the good work!
